### PR TITLE
Remove row hover effect from table styles.

### DIFF
--- a/Project_files/app/static/css/tables.css
+++ b/Project_files/app/static/css/tables.css
@@ -42,10 +42,6 @@
   transition: background-color 0.2s;
 }
 
-#table tbody tr:hover {
-  background-color: #f5f5f5; /* Row hover effect */
-}
-
 #table td {
   color: #333;
   font-size: 14px;


### PR DESCRIPTION
This pull request includes a small change to the `Project_files/app/static/css/tables.css` file. The change removes the row hover effect from the table rows.

* [`Project_files/app/static/css/tables.css`](diffhunk://#diff-56065c4bfe3fd05c49c268f67206e2d5814bb29e174980873cec38b2526079c0L45-L48): Removed the row hover effect by deleting the CSS rule that changes the background color of table rows on hover.