### PR TITLE
Added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
This pull request includes a small change to the `.gitattributes` file. The change marks Jupyter Notebook files (`*.ipynb`) as vendored to exclude them from language statistics.